### PR TITLE
Key value validation

### DIFF
--- a/lib/yaml_bot/validation_bot.rb
+++ b/lib/yaml_bot/validation_bot.rb
@@ -28,7 +28,6 @@ module YamlBot
         if yaml.keys.include?(key)
           validate_subkeys_or_accepted_types(yaml, key, keys, index, ancestors)
         else
-          ancestors = ancestors.join('.')
           log_missing_key(key_type, ancestors)
         end
       end
@@ -94,9 +93,9 @@ module YamlBot
     def log_missing_key(key_type, ancestors)
       if key_type == :required
         self.violations += 1
-        logger.error "Missing required key: '#{ancestors}'"
+        logger.error "Missing required key: '#{ancestors.join('.')}'"
       else
-        logger.warn "Optional key: '#{ancestors}' not utilized"
+        logger.warn "Optional key: '#{ancestors.join('.')}' not utilized"
       end
     end
 

--- a/lib/yaml_bot/version.rb
+++ b/lib/yaml_bot/version.rb
@@ -1,3 +1,3 @@
 module YamlBot
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/spec/fixtures/valid_rules_file_with_only_accepted_types.yml
+++ b/spec/fixtures/valid_rules_file_with_only_accepted_types.yml
@@ -1,0 +1,5 @@
+root_keys:
+  optional:
+    - language:
+        accepted_types:
+          - String

--- a/spec/fixtures/valid_rules_file_with_only_values.yml
+++ b/spec/fixtures/valid_rules_file_with_only_values.yml
@@ -1,0 +1,8 @@
+root_keys:
+  optional:
+    - language:
+        values:
+          - android
+          - go
+          - ruby
+          - shell

--- a/spec/fixtures/valid_rules_file_with_types_and_values.yml
+++ b/spec/fixtures/valid_rules_file_with_types_and_values.yml
@@ -1,0 +1,10 @@
+root_keys:
+  optional:
+    - language:
+        accepted_types:
+          - String
+        values:
+          - android
+          - go
+          - ruby
+          - shell

--- a/spec/yaml_bot/validation_bot_spec.rb
+++ b/spec/yaml_bot/validation_bot_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 require 'active_support/core_ext/hash/keys'
 require 'stringio'
 
+ESCAPES = { green: "\033[32m",
+            yellow: "\033[33m",
+            red: "\033[31m",
+            reset: "\033[0m" }.freeze
+
 describe YamlBot::ValidationBot do
   before :each do
     @yaml_bot = YamlBot::ValidationBot.new
@@ -51,8 +56,8 @@ describe YamlBot::ValidationBot do
         @yaml_bot.yaml_file = yaml_file
         key = 'key'
         value = true
-        msg = "Value: #{value} of class #{value.class} is not a valid type "\
-              "for key: #{key}\n"
+        msg = "Value: '#{value}' of class #{value.class} is not a valid type "\
+              "for key: '#{key}'\n"
 
         expect { @yaml_bot.scan }.to output(/#{msg}/).to_stdout
         expect(@yaml_bot.violations).to eq(1)
@@ -101,9 +106,9 @@ describe YamlBot::ValidationBot do
                           '/../fixtures/valid_rules_file.yml'
         yaml = { key1: { subkey1: 'value1', subkey2: 42 }, key2: 'value2' }
         msgs = [
-          'Key: key1.subkey1 successfully utilized with a value of value1',
-          'Key: key1.subkey2 successfully utilized with a value of 42',
-          'Key: key2 successfully utilized with a value of value2'
+          "Key: 'key1.subkey1' contains a value of a valid type String",
+          "Key: 'key1.subkey2' contains a value of a valid type Fixnum",
+          "Key: 'key2' contains a value of a valid type String"
         ]
         @yaml_bot.rules = YAML.load(
           File.open(rules_file_name)
@@ -113,6 +118,48 @@ describe YamlBot::ValidationBot do
         msgs.each do |msg|
           expect { @yaml_bot.scan }.to output(/#{msg}/).to_stdout
         end
+      end
+
+      it 'validates keys with accepted_types' do
+        file_name = '/../fixtures/valid_rules_file_with_only_accepted_types.yml'
+        rules_file_name = File.dirname(File.realpath(__FILE__)) + file_name
+        yaml = { language: 'go' }
+        msg = "Key: 'language' contains a value of a valid type String"
+        @yaml_bot.rules = YAML.load(
+          File.open(rules_file_name)
+        ).deep_symbolize_keys
+        @yaml_bot.yaml_file = yaml
+
+        expect { @yaml_bot.scan }.to output(/#{msg}/).to_stdout
+      end
+
+      it 'validates key values against a list of values' do
+        file_name = '/../fixtures/valid_rules_file_with_only_values.yml'
+        rules_file_name = File.dirname(File.realpath(__FILE__)) + file_name
+        yaml = { language: 'go' }
+        msg = "Key: 'language' contains valid value go"
+        @yaml_bot.rules = YAML.load(
+          File.open(rules_file_name)
+        ).deep_symbolize_keys
+        @yaml_bot.yaml_file = yaml
+
+        expect { @yaml_bot.scan }.to output(/#{msg}/).to_stdout
+      end
+
+      it 'validates keys with accepted_types and values' do
+        file_name = '/../fixtures/valid_rules_file_with_types_and_values.yml'
+        rules_file_name = File.dirname(File.realpath(__FILE__)) + file_name
+        yaml = { language: 'go' }
+        msg = "Key: 'language' contains valid value go"
+        msg = ESCAPES[:green] + msg + ESCAPES[:reset] + "\n"
+        msg += ESCAPES[:green] + "Key: 'language' contains a value of a "\
+               'valid type String' + ESCAPES[:reset] + "\n"
+        @yaml_bot.rules = YAML.load(
+          File.open(rules_file_name)
+        ).deep_symbolize_keys
+        @yaml_bot.yaml_file = yaml
+
+        expect { @yaml_bot.scan }.to output(msg).to_stdout
       end
     end
 

--- a/spec/yaml_bot/validation_bot_spec.rb
+++ b/spec/yaml_bot/validation_bot_spec.rb
@@ -44,19 +44,7 @@ describe YamlBot::ValidationBot do
       it 'logs an error message and increases the violation count when a key '\
          'has a value of an invalid type' do
         rules = {
-          root_keys:
-            {
-              required:
-                [
-                  {
-                    key:
-                      {
-                        accepted_types:
-                        ['Fixnum']
-                      }
-                  }
-                ]
-            }
+          root_keys: { required: [{ key: { accepted_types: ['Fixnum'] } }] }
         }
         yaml_file = { key: true }
         @yaml_bot.rules = rules


### PR DESCRIPTION
Previous behavior only allowed `yamlbot` to check that a particular value for a key was of a specific type.
Example: validating that the travis-ci language key value given is a `string`
```
root_keys:
  optional:
    language:
      accepted_types:
        - String
```

This change will allow users to specify a list of values to validate a key against.

Example: validating the travis-ci language key against a list of valid languages.
```
root_keys:
  optional:
    language:
      values:
        - 'android'
        - 'ruby'
        - 'python'
        - 'go'
        - 'java'
```

This will also give users the ability to validate a key contains any value

Example:
```
root_keys:
  optional:
    language:
      values:
        - '*'
```

Example: check `version` key contains any integer number
```
root_keys:
  required:
    version:
      accepted_types:
        - Fixnum
      values:
        - '*'
```

Example: check travis-ci `script` key contains any string
```
root_keys:
  required:
    script:
      accepted_types:
        - String
      values:
        - '*'
```