### PR TITLE
Update development dependencies in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,10 @@ Metrics/AbcSize:
 
 Metrics/CyclomaticComplexity:
   Max: 7
+
+Metrics/BlockLength:
+  Exclude:
+    - "**/*_spec.rb"
+
+Style/StderrPuts:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,4 @@ task :rubocop do
   cli.run
 end
 
-task default: [:rubocop, :spec]
+task default: %i[rubocop spec]

--- a/bin/yamlbot
+++ b/bin/yamlbot
@@ -1,15 +1,15 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift(File.dirname(File.realpath(__FILE__)) + '/../lib')
+$LOAD_PATH.unshift(File.dirname(File.realpath(__dir__)) + '/../lib')
 
 require 'optparse'
 require 'yaml_bot'
 require 'benchmark'
 
-banner = <<-eos
-I am YamlBot feed me YAML!
+banner = <<~BANNER
+  I am YamlBot feed me YAML!
 
-eos
+BANNER
 
 options = {}
 parser = OptionParser.new do |opts|

--- a/lib/yaml_bot/cli_bot.rb
+++ b/lib/yaml_bot/cli_bot.rb
@@ -73,13 +73,13 @@ module YamlBot
       puts "Finished scan...\n\n"
     end
 
-    def pluralize(n, singular, plural = nil)
-      if n == 1
+    def pluralize(num, singular, plural = nil)
+      if num == 1
         "1 #{singular}"
       elsif plural
-        "#{n} #{plural}"
+        "#{num} #{plural}"
       else
-        "#{n} #{singular}s"
+        "#{num} #{singular}s"
       end
     end
 

--- a/lib/yaml_bot/key_bot.rb
+++ b/lib/yaml_bot/key_bot.rb
@@ -14,13 +14,13 @@ module YamlBot
       boolean: [TrueClass, FalseClass]
     }.freeze
 
-    VALIDATION_CHECKS = [
-      :check_if_key_is_required,
-      :check_and_requires,
-      :check_or_requires,
-      :check_val_whitelist,
-      :check_val_blacklist,
-      :check_types
+    VALIDATION_CHECKS = %i[
+      check_if_key_is_required
+      check_and_requires
+      check_or_requires
+      check_val_whitelist
+      check_val_blacklist
+      check_types
     ].freeze
 
     def initialize(key, yaml_file, defaults)

--- a/lib/yaml_bot/logging_bot.rb
+++ b/lib/yaml_bot/logging_bot.rb
@@ -15,9 +15,9 @@ module YamlBot
                 yellow: "\033[33m",
                 red: "\033[31m",
                 reset: "\033[0m" }.freeze
-    LOGLEVEL = { info: [:info, :warn, :error],
-                 warn: [:warn, :error],
-                 error: [:error] }.freeze
+    LOGLEVEL = { info: %i[info warn error],
+                 warn: %i[warn error],
+                 error: %i[error] }.freeze
 
     attr_accessor :log_file, :log_level
 

--- a/lib/yaml_bot/parse_bot.rb
+++ b/lib/yaml_bot/parse_bot.rb
@@ -9,7 +9,7 @@ module YamlBot
         return nil
       end
 
-      return to_boolean(yaml[key_addr]) if %w(true false).include?(yaml[key_addr])
+      return to_boolean(yaml[key_addr]) if %w[true false].include?(yaml[key_addr])
       yaml[key_addr]
     rescue StandardError => e
       puts "Caught exception #{e}!"

--- a/lib/yaml_bot/rules_bot.rb
+++ b/lib/yaml_bot/rules_bot.rb
@@ -39,8 +39,8 @@ module YamlBot
     end
 
     def validate_rules_keys(key_map)
-      valid_keys = YAML.load_file(File.dirname(File.realpath(__FILE__)) +
-                   '/resources/valid_rules_keys.yml')
+      valid_keys = YAML.load_file(File.dirname(File.realpath(__dir__)) +
+                   '/yaml_bot/resources/valid_rules_keys.yml')
       invalid_keys = []
       key_map.keys.each { |k| invalid_keys << k unless valid_keys.include?(k) }
       return if invalid_keys.empty?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'yaml_bot'
 require 'simplecov'
 SimpleCov.start

--- a/spec/yaml_bot/cli_bot_spec.rb
+++ b/spec/yaml_bot/cli_bot_spec.rb
@@ -6,10 +6,10 @@ describe YamlBot::CLIBot do
     context 'Successful YAML validation' do
       it 'returns a zero exit code' do
         opts = {}
-        opts[:file] = File.dirname(File.realpath(__FILE__)) +
-                      '/../fixtures/valid_yaml.yml'
-        opts[:rules] = File.dirname(File.realpath(__FILE__)) +
-                       '/../fixtures/valid_rules.yml'
+        opts[:file] = File.dirname(File.realpath(__dir__)) +
+                      '/fixtures/valid_yaml.yml'
+        opts[:rules] = File.dirname(File.realpath(__dir__)) +
+                       '/fixtures/valid_rules.yml'
         cli_bot = YamlBot::CLIBot.new(opts)
         expect(cli_bot.run).to eq(0)
       end
@@ -18,10 +18,10 @@ describe YamlBot::CLIBot do
     context 'Failed YAML validation' do
       it 'returns a non-zero exit code' do
         opts = {}
-        opts[:file] = File.dirname(File.realpath(__FILE__)) +
-                      '/../fixtures/invalid_yaml_invalid_type.yml'
-        opts[:rules] = File.dirname(File.realpath(__FILE__)) +
-                       '/../fixtures/valid_rules.yml'
+        opts[:file] = File.dirname(File.realpath(__dir__)) +
+                      '/fixtures/invalid_yaml_invalid_type.yml'
+        opts[:rules] = File.dirname(File.realpath(__dir__)) +
+                       '/fixtures/valid_rules.yml'
         cli_bot = YamlBot::CLIBot.new(opts)
         expect(cli_bot.run).to eq(1)
       end

--- a/spec/yaml_bot/key_bot_spec.rb
+++ b/spec/yaml_bot/key_bot_spec.rb
@@ -5,10 +5,10 @@ describe YamlBot::KeyBot do
   describe '#validate' do
     context 'Valid yaml file' do
       before :each do
-        file_name = File.dirname(File.realpath(__FILE__)) +
-                    '/../fixtures/valid_yaml.yml'
-        rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                          '/../fixtures/valid_rules.yml'
+        file_name = File.dirname(File.realpath(__dir__)) +
+                    '/fixtures/valid_yaml.yml'
+        rules_file_name = File.dirname(File.realpath(__dir__)) +
+                          '/fixtures/valid_rules.yml'
         yaml = YAML.load_file(file_name)
         rules = YAML.load_file(rules_file_name)
         defaults = rules['defaults']
@@ -26,10 +26,10 @@ describe YamlBot::KeyBot do
 
     context 'Invalid yaml file' do
       it 'should return a violation if a required key is missing' do
-        file_name = File.dirname(File.realpath(__FILE__)) +
-                    '/../fixtures/invalid_yaml_missing_required_key.yml'
-        rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                          '/../fixtures/valid_rules.yml'
+        file_name = File.dirname(File.realpath(__dir__)) +
+                    '/fixtures/invalid_yaml_missing_required_key.yml'
+        rules_file_name = File.dirname(File.realpath(__dir__)) +
+                          '/fixtures/valid_rules.yml'
         yaml = YAML.load_file(file_name)
         rules = YAML.load_file(rules_file_name)
         key = rules['rules'].first
@@ -40,10 +40,10 @@ describe YamlBot::KeyBot do
       end
 
       it 'should return a violation if a required key and ["and_required"] keys are missing' do
-        file_name = File.dirname(File.realpath(__FILE__)) +
-                    '/../fixtures/invalid_yaml_missing_and_requires_keys.yml'
-        rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                          '/../fixtures/valid_rules_and_requires.yml'
+        file_name = File.dirname(File.realpath(__dir__)) +
+                    '/fixtures/invalid_yaml_missing_and_requires_keys.yml'
+        rules_file_name = File.dirname(File.realpath(__dir__)) +
+                          '/fixtures/valid_rules_and_requires.yml'
         yaml = YAML.load_file(file_name)
         rules = YAML.load_file(rules_file_name)
         key = rules['rules'].first
@@ -54,10 +54,10 @@ describe YamlBot::KeyBot do
       end
 
       it 'should return a violation if a required key or ["or_requires"] keys are missing' do
-        file_name = File.dirname(File.realpath(__FILE__)) +
-                    '/../fixtures/invalid_yaml_missing_or_requires_keys.yml'
-        rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                          '/../fixtures/valid_rules_or_requires.yml'
+        file_name = File.dirname(File.realpath(__dir__)) +
+                    '/fixtures/invalid_yaml_missing_or_requires_keys.yml'
+        rules_file_name = File.dirname(File.realpath(__dir__)) +
+                          '/fixtures/valid_rules_or_requires.yml'
         yaml = YAML.load_file(file_name)
         rules = YAML.load_file(rules_file_name)
         key = rules['rules'].first
@@ -68,10 +68,10 @@ describe YamlBot::KeyBot do
       end
 
       it 'should return a violation if value_whitelist is defined and key value is not in list' do
-        file_name = File.dirname(File.realpath(__FILE__)) +
-                    '/../fixtures/invalid_yaml_missing_whitelist_value.yml'
-        rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                          '/../fixtures/valid_rules_value_whitelist.yml'
+        file_name = File.dirname(File.realpath(__dir__)) +
+                    '/fixtures/invalid_yaml_missing_whitelist_value.yml'
+        rules_file_name = File.dirname(File.realpath(__dir__)) +
+                          '/fixtures/valid_rules_value_whitelist.yml'
         yaml = YAML.load_file(file_name)
         rules = YAML.load_file(rules_file_name)
         key = rules['rules'].first
@@ -82,10 +82,10 @@ describe YamlBot::KeyBot do
       end
 
       it 'should return a violation if a key has a blacklisted value' do
-        file_name = File.dirname(File.realpath(__FILE__)) +
-                    '/../fixtures/invalid_yaml_blacklist_value.yml'
-        rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                          '/../fixtures/valid_rules_value_blacklist.yml'
+        file_name = File.dirname(File.realpath(__dir__)) +
+                    '/fixtures/invalid_yaml_blacklist_value.yml'
+        rules_file_name = File.dirname(File.realpath(__dir__)) +
+                          '/fixtures/valid_rules_value_blacklist.yml'
         yaml = YAML.load_file(file_name)
         rules = YAML.load_file(rules_file_name)
         key = rules['rules'].first
@@ -97,10 +97,10 @@ describe YamlBot::KeyBot do
 
       context 'key may have a value of a single specified type' do
         it 'should return a violation if a key has a value that is not of a specified type' do
-          file_name = File.dirname(File.realpath(__FILE__)) +
-                      '/../fixtures/invalid_yaml_invalid_type.yml'
-          rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                            '/../fixtures/valid_rules_check_types_single.yml'
+          file_name = File.dirname(File.realpath(__dir__)) +
+                      '/fixtures/invalid_yaml_invalid_type.yml'
+          rules_file_name = File.dirname(File.realpath(__dir__)) +
+                            '/fixtures/valid_rules_check_types_single.yml'
           yaml = YAML.load_file(file_name)
           rules = YAML.load_file(rules_file_name)
           key = rules['rules'].first
@@ -113,10 +113,10 @@ describe YamlBot::KeyBot do
 
       context 'key may have a value of multiple specified types' do
         it 'should return a violation if a key has a value type that is not included in the specified types' do
-          file_name = File.dirname(File.realpath(__FILE__)) +
-                      '/../fixtures/invalid_yaml_invalid_type.yml'
-          rules_file_name = File.dirname(File.realpath(__FILE__)) +
-                            '/../fixtures/valid_rules_check_types_list.yml'
+          file_name = File.dirname(File.realpath(__dir__)) +
+                      '/fixtures/invalid_yaml_invalid_type.yml'
+          rules_file_name = File.dirname(File.realpath(__dir__)) +
+                            '/fixtures/valid_rules_check_types_list.yml'
           yaml = YAML.load_file(file_name)
           rules = YAML.load_file(rules_file_name)
           key = rules['rules'].first

--- a/spec/yaml_bot/parse_bot_spec.rb
+++ b/spec/yaml_bot/parse_bot_spec.rb
@@ -4,8 +4,8 @@ require 'yaml_bot/parse_bot'
 describe YamlBot::ParseBot do
   describe '::get_object_value' do
     before :each do
-      yaml_file = '/../fixtures/get_obj_val_test.yml'
-      @yaml = YAML.load_file(File.dirname(File.realpath(__FILE__)) + yaml_file)
+      yaml_file = '/fixtures/get_obj_val_test.yml'
+      @yaml = YAML.load_file(File.dirname(File.realpath(__dir__)) + yaml_file)
     end
 
     context 'Successfully retrieve value from Hash' do

--- a/spec/yaml_bot/rules_bot_spec.rb
+++ b/spec/yaml_bot/rules_bot_spec.rb
@@ -19,24 +19,24 @@ describe YamlBot::RulesBot do
 
     context 'successful validation' do
       it 'should not raise an error when a rules file is successfully validated' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/valid_rules.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/valid_rules.yml')
         expect { @rules_bot.validate_rules }.not_to raise_error
       end
 
       it 'should not raise an error when a key is not specified as required/not-required and there is a default' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/valid_rules_required_key_default.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/valid_rules_required_key_default.yml')
         expect { @rules_bot.validate_rules }.not_to raise_error
       end
     end
 
     context 'failed validation' do
       it 'should raise a ValidationError when a rules file has invalid defaults' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/invalid_rules_invalid_default.yml')
-        valid_keys = YAML.load_file(File.dirname(File.realpath(__FILE__)) +
-                     '/../../lib/yaml_bot/resources/valid_rules_keys.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/invalid_rules_invalid_default.yml')
+        valid_keys = YAML.load_file(File.dirname(File.realpath(__dir__)) +
+                     '/../lib/yaml_bot/resources/valid_rules_keys.yml')
         invalid_keys = ['invalid_key']
         msg = "Invalid key(s) specified in rules file: #{invalid_keys}\n"
         msg += "Valid rules keys include: #{valid_keys}\n"
@@ -45,10 +45,10 @@ describe YamlBot::RulesBot do
       end
 
       it 'should raise a ValidationError when a set of rules contains an invalid key' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/invalid_rules_invalid_rules_key.yml')
-        valid_keys = YAML.load_file(File.dirname(File.realpath(__FILE__)) +
-                     '/../../lib/yaml_bot/resources/valid_rules_keys.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/invalid_rules_invalid_rules_key.yml')
+        valid_keys = YAML.load_file(File.dirname(File.realpath(__dir__)) +
+                     '/../lib/yaml_bot/resources/valid_rules_keys.yml')
         invalid_keys = ['error_causing_key']
         msg = "Invalid key(s) specified in rules file: #{invalid_keys}\n"
         msg += "Valid rules keys include: #{valid_keys}\n"
@@ -57,16 +57,16 @@ describe YamlBot::RulesBot do
       end
 
       it 'should raise a ValidationError when a rules file is missing the rules key' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/invalid_rules_missing_rules.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/invalid_rules_missing_rules.yml')
         msg = 'rules section not defined in .yamlbot file'
 
         expect { @rules_bot.validate_rules }.to raise_error(YamlBot::ValidationError, msg)
       end
 
       it 'should raise a ValidationError when a set of rules is missing a key to validate' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/invalid_rules_missing_key_from_list.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/invalid_rules_missing_key_from_list.yml')
         msg = "Missing required key 'key' within rules file.\n"
         msg += "Or a key name has a value that is not a String.\n"
 
@@ -74,8 +74,8 @@ describe YamlBot::RulesBot do
       end
 
       it 'should raise a ValidationError when a set of rules has a key with a name that is not a string' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/invalid_rules_key_name_is_not_string.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/invalid_rules_key_name_is_not_string.yml')
         msg = "Missing required key 'key' within rules file.\n"
         msg += "Or a key name has a value that is not a String.\n"
 
@@ -83,8 +83,8 @@ describe YamlBot::RulesBot do
       end
 
       it 'should raise a ValidationError when a key isn\'t specified as required/not-required and there are no defaults' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/invalid_rules_missing_required_key.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/invalid_rules_missing_required_key.yml')
         key = 'jenkins.sudo'
         msg = "Missing required key 'required_key' for key: #{key}.\n"
         msg += "Or 'required_key' has a value that is not a Boolean.\n"
@@ -93,8 +93,8 @@ describe YamlBot::RulesBot do
       end
 
       it 'should raise a ValidationError when \'required_key\' has a value that is not boolean' do
-        load_rules_file(File.dirname(File.realpath(__FILE__)) +
-                        '/../fixtures/invalid_rules_required_key_with_non_boolean_value.yml')
+        load_rules_file(File.dirname(File.realpath(__dir__)) +
+                        '/fixtures/invalid_rules_required_key_with_non_boolean_value.yml')
         key = 'language'
         msg = "Missing required key 'required_key' for key: #{key}.\n"
         msg += "Or 'required_key' has a value that is not a Boolean.\n"

--- a/spec/yaml_bot/validation_bot_spec.rb
+++ b/spec/yaml_bot/validation_bot_spec.rb
@@ -18,16 +18,16 @@ describe YamlBot::ValidationBot do
 
     context 'yaml file not successfully validated against specified rules' do
       it 'should return the number of violations in the yaml file' do
-        @yaml_bot.rules = YAML.load_file(File.dirname(File.realpath(__FILE__)) +
-                                         '/../fixtures/valid_rules.yml')
+        @yaml_bot.rules = YAML.load_file(File.dirname(File.realpath(__dir__)) +
+                                         '/fixtures/valid_rules.yml')
         {
-          '/../fixtures/validation_test1.yml' => 1,
-          '/../fixtures/validation_test2.yml' => 2,
-          '/../fixtures/validation_test3.yml' => 3,
-          '/../fixtures/validation_test4.yml' => 4,
-          '/../fixtures/validation_test5.yml' => 5
+          '/fixtures/validation_test1.yml' => 1,
+          '/fixtures/validation_test2.yml' => 2,
+          '/fixtures/validation_test3.yml' => 3,
+          '/fixtures/validation_test4.yml' => 4,
+          '/fixtures/validation_test5.yml' => 5
         }.each do |yaml_file, num_of_violations|
-          yaml = File.dirname(File.realpath(__FILE__)) + yaml_file
+          yaml = File.dirname(File.realpath(__dir__)) + yaml_file
           @yaml_bot.yaml_file = YAML.load_file(yaml)
           expect(@yaml_bot.scan).to eq(num_of_violations)
           @yaml_bot.violations = 0

--- a/yaml_bot.gemspec
+++ b/yaml_bot.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'yaml_bot/version'
 
@@ -19,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.46.0'
+  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'rake', '~> 10.5.0'
+  spec.add_development_dependency 'rspec', '~> 3.7.0'
+  spec.add_development_dependency 'rubocop', '~> 0.54.0'
 
   spec.required_ruby_version = '>=2.4'
 end


### PR DESCRIPTION
Updating Rubocop gem to address an open security vulnerability in Rubocop.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418

- Fix several Rubocop offenses